### PR TITLE
Add C++ header guard & Fix OpSource

### DIFF
--- a/inc/spvm/analyzer.h
+++ b/inc/spvm/analyzer.h
@@ -3,6 +3,10 @@
 
 #include <spvm/types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 enum spvm_undefined_behavior {
 	spvm_undefined_behavior_none,							// not an undefined behavior
 	spvm_undefined_behavior_div_by_zero,					// a/b when b == 0
@@ -35,5 +39,8 @@ typedef struct spvm_analyzer {
 } spvm_analyzer;
 typedef struct spvm_analyzer* spvm_analyzer_t;
 
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 
 #endif // __SPIRV_VM_ANALYZER_H__

--- a/inc/spvm/context.h
+++ b/inc/spvm/context.h
@@ -3,6 +3,10 @@
 
 #include <spvm/opcode.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 #define SPVM_OPCODE_TABLE_LENGTH 405
 
 typedef struct spvm_context {
@@ -17,5 +21,9 @@ void spvm_context_deinitialize(spvm_context_t ctx);
 /* PRIVATE FUNCTIONS */
 void _spvm_context_create_execute_table(spvm_context_t ctx);
 void _spvm_context_create_setup_table(spvm_context_t ctx);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 
 #endif // __SPIRV_VM_CONTEXT_H__

--- a/inc/spvm/image.h
+++ b/inc/spvm/image.h
@@ -1,6 +1,10 @@
 #ifndef __SPIRV_VM_IMAGE_H__
 #define __SPIRV_VM_IMAGE_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 typedef struct spvm_image {
 	float* data;
 
@@ -16,5 +20,9 @@ void spvm_image_create(spvm_image_t img, float* data, int width, int height, int
 float* spvm_image_sample(spvm_image_t img, float s, float t, float u);
 float* spvm_image_read(spvm_image_t img, int x, int y, int z);
 void spvm_image_write(spvm_image_t img, int x, int y, int z, float* rgba);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 
 #endif // __SPIRV_VM_IMAGE_H__

--- a/inc/spvm/opcode.h
+++ b/inc/spvm/opcode.h
@@ -3,9 +3,17 @@
 
 #include <spvm/types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 struct spvm_state;
 
 typedef void(*spvm_opcode_func)(spvm_word word_count, struct spvm_state* state);
 typedef void(*spvm_ext_opcode_func)(spvm_word type, spvm_word id, spvm_word word_count, struct spvm_state* state);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 
 #endif // __SPIRV_VM_OPCODE_H__

--- a/inc/spvm/program.h
+++ b/inc/spvm/program.h
@@ -5,6 +5,10 @@
 #include <spvm/spirv.h>
 #include <spvm/context.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 typedef struct
 {
 	SpvExecutionModel exec_model;
@@ -13,6 +17,14 @@ typedef struct
 	spvm_word globals_count;
 	spvm_word* globals; // interface <id>
 } spvm_entry_point;
+
+typedef struct
+{
+	spvm_string name; // points to OpString result
+	SpvSourceLanguage language;
+	spvm_word language_version;
+	spvm_string source;
+} spvm_file;
 
 typedef struct {
 	spvm_context_t context;
@@ -23,13 +35,13 @@ typedef struct {
 	spvm_word generator_id;
 	spvm_word generator_version;
 
-	spvm_word bound;
+	size_t file_count;
+	spvm_file* files;
+
+	unsigned bound;
 
 	size_t code_length;
 	spvm_source code;
-
-	SpvSourceLanguage language;
-	spvm_word language_version;
 
 	spvm_word extension_count;
 	spvm_string* extensions;
@@ -68,5 +80,9 @@ spvm_string spvm_program_add_extension(spvm_program_t prog, spvm_word length);
 spvm_entry_point* spvm_program_create_entry_point(spvm_program_t prog);
 void spvm_program_add_capability(spvm_program_t prog, SpvCapability cap);
 void spvm_program_delete(spvm_program_t prog);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 
 #endif // __SPIRV_VM_PROGRAM_H__

--- a/inc/spvm/result.h
+++ b/inc/spvm/result.h
@@ -1,6 +1,10 @@
 #ifndef __SPIRV_VM_RESULT_H__
 #define __SPIRV_VM_RESULT_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 #include <spvm/types.h>
 #include <spvm/value.h>
 #include <spvm/spirv.h>
@@ -86,5 +90,9 @@ void spvm_member_allocate_value(spvm_member_t val, spvm_word count);
 void spvm_member_allocate_typed_value(spvm_member_t val, spvm_result* results, spvm_word type);
 spvm_word spvm_result_calculate_size(spvm_result_t results, spvm_word type);
 void spvm_member_recursive_fill(spvm_result_t results, float* data, spvm_member_t values, spvm_word value_count, spvm_word element_type, spvm_word* offset); // offset is number of 4byte elements
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 
 #endif // __SPIRV_VM_RESULT_H__

--- a/inc/spvm/state.h
+++ b/inc/spvm/state.h
@@ -5,6 +5,10 @@
 #include <spvm/result.h>
 #include <spvm/analyzer.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 typedef struct spvm_state {
 	spvm_context_t context;
 	spvm_program_t owner;
@@ -81,5 +85,9 @@ spvm_member_t spvm_state_get_object_member(spvm_state_t state, spvm_result_t var
 void spvm_state_push_function_stack(spvm_state_t state, spvm_result_t func, spvm_word func_res_id);
 void spvm_state_pop_function_stack(spvm_state_t state);
 void spvm_state_delete(spvm_state_t state);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 
 #endif // __SPIRV_VM_STATE_H__

--- a/inc/spvm/types.h
+++ b/inc/spvm/types.h
@@ -3,9 +3,13 @@
 
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 typedef unsigned char spvm_byte;
 typedef int spvm_word;
-typedef spvm_word* spvm_source;
+typedef const spvm_word* spvm_source;
 typedef char* spvm_string;
 struct spvm_state;
 
@@ -14,5 +18,9 @@ struct spvm_state;
 
 void spvm_string_read(spvm_source spv, spvm_string str, spvm_word length);
 spvm_string spvm_string_read_all(spvm_source spv, spvm_word* length);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 
 #endif // __SPIRV_VM_TYPES_H__

--- a/inc/spvm/value.h
+++ b/inc/spvm/value.h
@@ -4,6 +4,10 @@
 #include <spvm/types.h>
 #include <spvm/image.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 #define CLAMP(x, minVal, maxVal) MIN(MAX((x), (minVal)), (maxVal))
@@ -42,7 +46,7 @@ typedef struct spvm_member {
 	} value;
 
 	spvm_image_t image_data;
-	
+
 	spvm_word member_count;
 	struct spvm_member* members;
 } spvm_member;
@@ -53,5 +57,9 @@ void spvm_member_memcpy(spvm_member_t target, spvm_member_t source, spvm_word va
 
 void spvm_member_set_value_f(spvm_member_t mems, size_t mem_count, float* f);
 void spvm_member_set_value_i(spvm_member_t mems, size_t mem_count,  int* d);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 
 #endif // __SPIRV_VM_VALUE_H__

--- a/src/program.c
+++ b/src/program.c
@@ -78,5 +78,8 @@ void spvm_program_delete(spvm_program_t prog)
 	if (prog->capability_count)
 		free(prog->capabilities);
 
+	if (prog->file_count)
+		free(prog->files);
+
 	free(prog);
 }


### PR DESCRIPTION
Just a collection of small changes I needed to use the library.

- This makes using the library from C++ easier by adding `extern "C"` header guards.
- This makes sure OpSource works if the source files are embedded (and correctly stores them in the program).
- The source data passed into spvm can be const, spvm doesn't ever modify it afaik.
- (my editor automatically removed some whitespace if that's an issue I can revert it).