### PR TITLE
Improve image sampling implementation

### DIFF
--- a/inc/spvm/analyzer.h
+++ b/inc/spvm/analyzer.h
@@ -31,6 +31,7 @@ enum spvm_undefined_behavior {
 	spvm_undefined_behavior_smoothstep,						// smoothstep(edge0, edge1, x) when edge0 >= edge1
 	spvm_undefined_behavior_frexp,							// frexp(x, out exp) when x is NaN or inf
 	spvm_undefined_behavior_ldexp,							// ldexp(x, exp) when exp > 128 (float) or exp > 1024 (double)
+	spvm_undefined_behavior_image_gather_invalid_comp,		// OpImageGather -> component not in {0, 1, 2, 3}
 	spvm_undefined_behavior_count
 };
 

--- a/inc/spvm/image.h
+++ b/inc/spvm/image.h
@@ -5,21 +5,113 @@
 extern "C" {
 #endif // __cplusplus
 
+struct spvm_state;
+struct spvm_image;
+struct spvm_result;
+struct spvm_image_info;
+
+typedef struct spvm_vec4f {
+	float data[4];
+} spvm_vec4f;
+
 typedef struct spvm_image {
-	float* data;
-
-	int width;
-	int height;
-	int depth;
-
-	void* user_data;
+	// Size values of the first (base) mip level accessible to the shader.
+	// If the full image has size 1024x1024 but the imageView/texture bound
+	// to the descriptor has firstLevel = 2, expects 256x256 here.
+	unsigned width;
+	unsigned height;
+	unsigned depth;
+	unsigned layers;
+	unsigned levels;
+	// TODO: support for multisampling
 } spvm_image;
-typedef spvm_image* spvm_image_t;
 
-void spvm_image_create(spvm_image_t img, float* data, int width, int height, int depth);
-float* spvm_image_sample(spvm_image_t img, float s, float t, float u);
-float* spvm_image_read(spvm_image_t img, int x, int y, int z);
-void spvm_image_write(spvm_image_t img, int x, int y, int z, float* rgba);
+// Sampler definition, close to VkSamplerCreateInfo
+typedef enum spvm_sampler_filter {
+	spvm_sampler_filter_nearest,
+	spvm_sampler_filter_linear,
+} spvm_sampler_filter;
+
+typedef enum spvm_sampler_address_mode {
+	spvm_sampler_address_mode_repeat,
+	spvm_sampler_address_mode_mirrored_repeat,
+	spvm_sampler_address_mode_clamp_to_edge,
+	spvm_sampler_address_mode_clamp_to_border,
+} spvm_sampler_address_mode;
+
+typedef enum spvm_sampler_compare_op {
+	spvm_sampler_compare_op_never,
+	spvm_sampler_compare_op_less,
+	spvm_sampler_compare_op_equal,
+	spvm_sampler_compare_op_less_or_equal,
+	spvm_sampler_compare_op_greater,
+	spvm_sampler_compare_op_not_equal,
+	spvm_sampler_compare_op_greater_or_equal,
+	spvm_sampler_compare_op_always,
+} spvm_sampler_compare_op;
+
+typedef struct spvm_sampler_desc {
+	spvm_sampler_filter filter_min;
+	spvm_sampler_filter filter_mag;
+	spvm_sampler_filter mipmap_mode;
+	spvm_sampler_address_mode address_mode_u;
+	spvm_sampler_address_mode address_mode_v;
+	spvm_sampler_address_mode address_mode_w;
+	spvm_vec4f border_color;
+	float mip_bias;
+	spvm_sampler_compare_op compare_op;
+	float min_lod;
+	float max_lod;
+	// TODO: no support for anisotropy yet
+	// TODO: no support for unnormalized coordinates yet
+} spvm_sampler_desc;
+
+typedef struct spvm_sampler {
+	spvm_sampler_desc desc;
+} spvm_sampler;
+
+spvm_vec4f spvm_image_read(struct spvm_state*, spvm_image*,
+	int x, int y, int z, int layer, int level);
+void spvm_image_write(struct spvm_state*, spvm_image*,
+	int x, int y, int z, int layer, int level, const spvm_vec4f* data);
+spvm_vec4f spvm_sampled_image_sample(struct spvm_state*, spvm_image*, spvm_sampler*,
+	float x, float y, float z, float layer, float level);
+
+// Applies the addressing mode from the sampler but always just
+// reads a single texel.
+spvm_vec4f spvm_fetch_texel(struct spvm_state* state,
+	spvm_image* img, const spvm_sampler_desc* desc, int x, int y, int z, int layer, int level);
+
+// spvm_image implementation
+// Functions will interpret user_data as float* with tight layout
+// and directly read/write it.
+typedef struct spvm_image_data {
+	struct spvm_image base;
+	spvm_vec4f* data;
+} spvm_image_data;
+
+void spvm_image_create(struct spvm_image_data* dst, float* data, int width, int height, int depth);
+void spvm_image_create_ext(struct spvm_image_data* dst, float* data,
+	int width, int height, int depth, int layers, int levels);
+spvm_vec4f spvm_image_read_impl(struct spvm_state*, struct spvm_image*,
+	int x, int y, int z, int layer, int level);
+void spvm_image_write_impl(struct spvm_state*, struct spvm_image*,
+	int x, int y, int z, int layer, int level, const spvm_vec4f* data);
+
+struct spvm_sampled_image_lod_query {
+	float lambda_prime; // the level without any clamping/rounding
+	float dl; // the selected level
+};
+
+// Expects the coords to be loaded into the derivative buffers of the given state.
+struct spvm_sampled_image_lod_query spvm_sampled_image_query_lod(
+	struct spvm_state*, spvm_image*, const struct spvm_image_info*, spvm_sampler*,
+	unsigned coord_id, float shader_lod_bias, float shader_lod_min);
+
+// For cubemaps, ddx and ddy must already correspond to the selected face.
+struct spvm_sampled_image_lod_query spvm_sampled_image_query_lod_from_grad(
+	struct spvm_state*, spvm_image*, const struct spvm_image_info*, spvm_sampler*,
+	float* ddx/*[3]*/, float* ddy/*[3]*/, float shader_lod_bias, float shader_lod_min);
 
 #ifdef __cplusplus
 }

--- a/inc/spvm/result.h
+++ b/inc/spvm/result.h
@@ -23,7 +23,7 @@ enum spvm_result_type {
 	spvm_result_type_function_parameter,
 	spvm_result_type_label
 };
-typedef struct {
+typedef struct spvm_image_info {
 	SpvDim dim;
 	spvm_byte depth;
 	spvm_byte arrayed;
@@ -32,7 +32,7 @@ typedef struct {
 	SpvImageFormat format;
 	SpvAccessQualifier access;
 } spvm_image_info;
-typedef struct {
+typedef struct spvm_decoration {
 	SpvDecoration type;
 	spvm_word literal1, literal2;
 	spvm_word index; // member

--- a/inc/spvm/state.h
+++ b/inc/spvm/state.h
@@ -9,6 +9,11 @@
 extern "C" {
 #endif // __cplusplus
 
+typedef spvm_vec4f (*spvm_image_read_fn)(struct spvm_state*, struct spvm_image*,
+	int x, int y, int z, int layer, int level);
+typedef void (*spvm_image_write_fn)(struct spvm_state*, struct spvm_image*,
+	int x, int y, int z, int layer, int level, const spvm_vec4f* data);
+
 typedef struct spvm_state {
 	spvm_context_t context;
 	spvm_program_t owner;
@@ -34,6 +39,9 @@ typedef struct spvm_state {
 	void(*end_primitive)(struct spvm_state*, spvm_word);
 
 	void(*control_barrier)(struct spvm_state*, spvm_word, spvm_word, spvm_word);
+
+	spvm_image_read_fn read_image;
+	spvm_image_write_fn write_image;
 
 	float frag_coord[4];
 

--- a/inc/spvm/value.h
+++ b/inc/spvm/value.h
@@ -8,13 +8,13 @@
 extern "C" {
 #endif // __cplusplus
 
-#define MAX(x, y) (((x) > (y)) ? (x) : (y))
-#define MIN(x, y) (((x) < (y)) ? (x) : (y))
-#define CLAMP(x, minVal, maxVal) MIN(MAX((x), (minVal)), (maxVal))
-#define NMAX(x, y) (isnan(x) ? (y) : (isnan(y) ? (x) : MAX(x,y)))
-#define NMIN(x, y) (isnan(x) ? (y) : (isnan(y) ? (x) : MIN(x,y)))
-#define NCLAMP(x, minVal, maxVal) NMIN(NMAX((x), (minVal)), (maxVal))
-#define SIGN(x) ((x) > 0) - ((x) < 0)
+#define SPVM_MAX(x, y) (((x) > (y)) ? (x) : (y))
+#define SPVM_MIN(x, y) (((x) < (y)) ? (x) : (y))
+#define SPVM_CLAMP(x, minVal, maxVal) SPVM_MIN(SPVM_MAX((x), (minVal)), (maxVal))
+#define SPVM_NMAX(x, y) (isnan(x) ? (y) : (isnan(y) ? (x) : SPVM_MAX(x,y)))
+#define SPVM_NMIN(x, y) (isnan(x) ? (y) : (isnan(y) ? (x) : SPVM_MIN(x,y)))
+#define SPVM_NCLAMP(x, minVal, maxVal) SPVM_NMIN(SPVM_NMAX((x), (minVal)), (maxVal))
+#define SPVM_SIGN(x) ((x) > 0) - ((x) < 0)
 
 enum spvm_value_type
 {
@@ -28,6 +28,7 @@ enum spvm_value_type
 	spvm_value_type_runtime_array,
 	spvm_value_type_struct,
 	spvm_value_type_image,
+	spvm_value_type_sampler,
 	spvm_value_type_sampled_image,
 	spvm_value_type_pointer
 };
@@ -43,9 +44,9 @@ typedef struct spvm_member {
 		unsigned int u;
 		unsigned long long u64;
 		char b;
+		spvm_image* image;
+		spvm_sampler* sampler;
 	} value;
-
-	spvm_image_t image_data;
 
 	spvm_word member_count;
 	struct spvm_member* members;

--- a/src/ext/GLSL450.c
+++ b/src/ext/GLSL450.c
@@ -172,7 +172,7 @@ void spvm_execute_GLSL450_Asin(spvm_word type, spvm_word id, spvm_word word_coun
 
 	for (spvm_word i = 0; i < state->results[id].member_count; i++) {
 		state->results[id].members[i].value.f = asinf(state->results[x].members[i].value.f);
-	
+
 		if (state->analyzer && fabsf(state->results[x].members[i].value.f) > 1.0f)
 			state->analyzer->on_undefined_behavior(state, spvm_undefined_behavior_acos);
 	}
@@ -229,7 +229,7 @@ void spvm_execute_GLSL450_Acosh(spvm_word type, spvm_word id, spvm_word word_cou
 
 	for (spvm_word i = 0; i < state->results[id].member_count; i++) {
 		state->results[id].members[i].value.f = acoshf(state->results[x].members[i].value.f);
-	
+
 		if (state->analyzer && state->results[x].members[i].value.f < 1.0f)
 			state->analyzer->on_undefined_behavior(state, spvm_undefined_behavior_acosh);
 	}
@@ -264,7 +264,7 @@ void spvm_execute_GLSL450_Pow(spvm_word type, spvm_word id, spvm_word word_count
 
 	for (spvm_word i = 0; i < state->results[id].member_count; i++) {
 		state->results[id].members[i].value.f = powf(state->results[x].members[i].value.f, state->results[y].members[i].value.f);
-		
+
 		if (state->analyzer && (state->results[x].members[i].value.f < 0.0f ||
 			(state->results[x].members[i].value.f == 0.0f && state->results[y].members[i].value.f <= 0.0f)))
 			state->analyzer->on_undefined_behavior(state, spvm_undefined_behavior_pow);
@@ -391,7 +391,7 @@ void spvm_execute_GLSL450_Determinant(spvm_word type, spvm_word id, spvm_word wo
 	double m[4][4];
 	spvm_result_t type_info = spvm_state_get_type_info(state->results, &state->results[type]);
 	spvm_word mtype = state->results[x].member_count;
-	
+
 	matrix_to_array_d(&m[0][0], type_info->value_bitcount > 32, state->results[x].members, mtype);
 	double res = matrix_determinant(&m[0][0], mtype);
 
@@ -518,14 +518,14 @@ void spvm_execute_GLSL450_FMin(spvm_word type, spvm_word id, spvm_word word_coun
 
 	if (type_info->value_bitcount > 32)
 		for (spvm_word i = 0; i < state->results[id].member_count; i++) {
-			state->results[id].members[i].value.d = MIN(state->results[x].members[i].value.d, state->results[y].members[i].value.d);
+			state->results[id].members[i].value.d = SPVM_MIN(state->results[x].members[i].value.d, state->results[y].members[i].value.d);
 
 			if (state->analyzer && (isnan(state->results[x].members[i].value.d) || isnan(state->results[y].members[i].value.d)))
 				state->analyzer->on_undefined_behavior(state, spvm_undefined_behavior_fmin);
 		}
 	else
 		for (spvm_word i = 0; i < state->results[id].member_count; i++) {
-			state->results[id].members[i].value.f = MIN(state->results[x].members[i].value.f, state->results[y].members[i].value.f);
+			state->results[id].members[i].value.f = SPVM_MIN(state->results[x].members[i].value.f, state->results[y].members[i].value.f);
 
 			if (state->analyzer && (isnan(state->results[x].members[i].value.f) || isnan(state->results[y].members[i].value.f)))
 				state->analyzer->on_undefined_behavior(state, spvm_undefined_behavior_fmin);
@@ -537,7 +537,7 @@ void spvm_execute_GLSL450_UMin(spvm_word type, spvm_word id, spvm_word word_coun
 	spvm_word y = SPVM_READ_WORD(state->code_current);
 
 	for (spvm_word i = 0; i < state->results[id].member_count; i++)
-		state->results[id].members[i].value.u64 = MIN(state->results[x].members[i].value.u64, state->results[y].members[i].value.u64);
+		state->results[id].members[i].value.u64 = SPVM_MIN(state->results[x].members[i].value.u64, state->results[y].members[i].value.u64);
 }
 void spvm_execute_GLSL450_SMin(spvm_word type, spvm_word id, spvm_word word_count, spvm_state_t state)
 {
@@ -545,7 +545,7 @@ void spvm_execute_GLSL450_SMin(spvm_word type, spvm_word id, spvm_word word_coun
 	spvm_word y = SPVM_READ_WORD(state->code_current);
 
 	for (spvm_word i = 0; i < state->results[id].member_count; i++)
-		state->results[id].members[i].value.s = MIN(state->results[x].members[i].value.s, state->results[y].members[i].value.s);
+		state->results[id].members[i].value.s = SPVM_MIN(state->results[x].members[i].value.s, state->results[y].members[i].value.s);
 }
 void spvm_execute_GLSL450_FMax(spvm_word type, spvm_word id, spvm_word word_count, spvm_state_t state)
 {
@@ -556,14 +556,14 @@ void spvm_execute_GLSL450_FMax(spvm_word type, spvm_word id, spvm_word word_coun
 
 	if (type_info->value_bitcount > 32)
 		for (spvm_word i = 0; i < state->results[id].member_count; i++) {
-			state->results[id].members[i].value.d = MAX(state->results[x].members[i].value.d, state->results[y].members[i].value.d);
+			state->results[id].members[i].value.d = SPVM_MAX(state->results[x].members[i].value.d, state->results[y].members[i].value.d);
 
 			if (state->analyzer && (isnan(state->results[x].members[i].value.d) || isnan(state->results[y].members[i].value.d)))
 				state->analyzer->on_undefined_behavior(state, spvm_undefined_behavior_fmax);
 		}
 	else
 		for (spvm_word i = 0; i < state->results[id].member_count; i++) {
-			state->results[id].members[i].value.f = MAX(state->results[x].members[i].value.f, state->results[y].members[i].value.f);
+			state->results[id].members[i].value.f = SPVM_MAX(state->results[x].members[i].value.f, state->results[y].members[i].value.f);
 
 			if (state->analyzer && (isnan(state->results[x].members[i].value.f) || isnan(state->results[y].members[i].value.f)))
 				state->analyzer->on_undefined_behavior(state, spvm_undefined_behavior_fmax);
@@ -575,7 +575,7 @@ void spvm_execute_GLSL450_UMax(spvm_word type, spvm_word id, spvm_word word_coun
 	spvm_word y = SPVM_READ_WORD(state->code_current);
 
 	for (spvm_word i = 0; i < state->results[id].member_count; i++)
-		state->results[id].members[i].value.u64 = MAX(state->results[x].members[i].value.u64, state->results[y].members[i].value.u64);
+		state->results[id].members[i].value.u64 = SPVM_MAX(state->results[x].members[i].value.u64, state->results[y].members[i].value.u64);
 }
 void spvm_execute_GLSL450_SMax(spvm_word type, spvm_word id, spvm_word word_count, spvm_state_t state)
 {
@@ -583,7 +583,7 @@ void spvm_execute_GLSL450_SMax(spvm_word type, spvm_word id, spvm_word word_coun
 	spvm_word y = SPVM_READ_WORD(state->code_current);
 
 	for (spvm_word i = 0; i < state->results[id].member_count; i++)
-		state->results[id].members[i].value.s = MAX(state->results[x].members[i].value.s, state->results[y].members[i].value.s);
+		state->results[id].members[i].value.s = SPVM_MAX(state->results[x].members[i].value.s, state->results[y].members[i].value.s);
 }
 void spvm_execute_GLSL450_FClamp(spvm_word type, spvm_word id, spvm_word word_count, spvm_state_t state)
 {
@@ -595,15 +595,15 @@ void spvm_execute_GLSL450_FClamp(spvm_word type, spvm_word id, spvm_word word_co
 
 	if (type_info->value_bitcount > 32)
 		for (spvm_word i = 0; i < state->results[id].member_count; i++) {
-			state->results[id].members[i].value.d = CLAMP(state->results[x].members[i].value.d, state->results[minVal].members[i].value.d, state->results[maxVal].members[i].value.d);
+			state->results[id].members[i].value.d = SPVM_CLAMP(state->results[x].members[i].value.d, state->results[minVal].members[i].value.d, state->results[maxVal].members[i].value.d);
 
 			if (state->analyzer && (state->results[minVal].members[i].value.d > state->results[maxVal].members[i].value.d))
 				state->analyzer->on_undefined_behavior(state, spvm_undefined_behavior_clamp);
 		}
 	else
 		for (spvm_word i = 0; i < state->results[id].member_count; i++) {
-			state->results[id].members[i].value.f = CLAMP(state->results[x].members[i].value.f, state->results[minVal].members[i].value.f, state->results[maxVal].members[i].value.f);
-			
+			state->results[id].members[i].value.f = SPVM_CLAMP(state->results[x].members[i].value.f, state->results[minVal].members[i].value.f, state->results[maxVal].members[i].value.f);
+
 			if (state->analyzer && (state->results[minVal].members[i].value.f > state->results[maxVal].members[i].value.f))
 				state->analyzer->on_undefined_behavior(state, spvm_undefined_behavior_clamp);
 		}
@@ -616,8 +616,8 @@ void spvm_execute_GLSL450_UClamp(spvm_word type, spvm_word id, spvm_word word_co
 	spvm_word maxVal = SPVM_READ_WORD(state->code_current);
 
 	for (spvm_word i = 0; i < state->results[id].member_count; i++) {
-		state->results[id].members[i].value.u64 = CLAMP(state->results[x].members[i].value.u64, state->results[minVal].members[i].value.u64, state->results[maxVal].members[i].value.u64);
-		
+		state->results[id].members[i].value.u64 = SPVM_CLAMP(state->results[x].members[i].value.u64, state->results[minVal].members[i].value.u64, state->results[maxVal].members[i].value.u64);
+
 		if (state->analyzer && (state->results[minVal].members[i].value.u64 > state->results[maxVal].members[i].value.u64))
 			state->analyzer->on_undefined_behavior(state, spvm_undefined_behavior_clamp);
 	}
@@ -629,7 +629,7 @@ void spvm_execute_GLSL450_SClamp(spvm_word type, spvm_word id, spvm_word word_co
 	spvm_word maxVal = SPVM_READ_WORD(state->code_current);
 
 	for (spvm_word i = 0; i < state->results[id].member_count; i++) {
-		state->results[id].members[i].value.s = CLAMP(state->results[x].members[i].value.s, state->results[minVal].members[i].value.s, state->results[maxVal].members[i].value.s);
+		state->results[id].members[i].value.s = SPVM_CLAMP(state->results[x].members[i].value.s, state->results[minVal].members[i].value.s, state->results[maxVal].members[i].value.s);
 
 		if (state->analyzer && (state->results[minVal].members[i].value.s > state->results[maxVal].members[i].value.s))
 			state->analyzer->on_undefined_behavior(state, spvm_undefined_behavior_clamp);
@@ -685,11 +685,11 @@ void spvm_execute_GLSL450_SmoothStep(spvm_word type, spvm_word id, spvm_word wor
 			if (edge0Val == edge1Val) {
 				state->results[id].members[i].value.d = 0.0;
 			} else {
-				xVal = CLAMP((xVal - edge0Val) / (edge1Val - edge0Val), 0.0, 1.0);
+				xVal = SPVM_CLAMP((xVal - edge0Val) / (edge1Val - edge0Val), 0.0, 1.0);
 				state->results[id].members[i].value.d = xVal * xVal * (3.0 - 2.0 * xVal);
 			}
 
-			
+
 			if (state->analyzer && edge0Val > edge1Val)
 				state->analyzer->on_undefined_behavior(state, spvm_undefined_behavior_smoothstep);
 		}
@@ -702,7 +702,7 @@ void spvm_execute_GLSL450_SmoothStep(spvm_word type, spvm_word id, spvm_word wor
 			if (edge0Val == edge1Val) {
 				state->results[id].members[i].value.f = 0.0f;
 			} else {
-				xVal = CLAMP((xVal - edge0Val) / (edge1Val - edge0Val), 0.0f, 1.0f);
+				xVal = SPVM_CLAMP((xVal - edge0Val) / (edge1Val - edge0Val), 0.0f, 1.0f);
 				state->results[id].members[i].value.f = xVal * xVal * (3.0f - 2.0f * xVal);
 			}
 
@@ -735,7 +735,7 @@ void spvm_execute_GLSL450_Frexp(spvm_word type, spvm_word id, spvm_word word_cou
 	if (type_info->value_bitcount > 32)
 		for (spvm_word i = 0; i < state->results[id].member_count; i++) {
 			state->results[id].members[i].value.d = frexp(state->results[x].members[i].value.d, &state->results[out].members[i].value.s);
-			
+
 			if (state->analyzer && (isnan(state->results[x].members[i].value.d) || isinf(state->results[x].members[i].value.d)))
 				state->analyzer->on_undefined_behavior(state, spvm_undefined_behavior_frexp);
 		}
@@ -770,8 +770,8 @@ void spvm_execute_GLSL450_Ldexp(spvm_word type, spvm_word id, spvm_word word_cou
 	if (type_info->value_bitcount > 32)
 		for (spvm_word i = 0; i < state->results[id].member_count; i++) {
 			state->results[id].members[i].value.d = ldexp(state->results[x].members[i].value.d, state->results[exp].members[i].value.s);
-		
-			
+
+
 			if (state->analyzer && state->results[exp].members[i].value.d > 1024)
 				state->analyzer->on_undefined_behavior(state, spvm_undefined_behavior_ldexp);
 		}
@@ -789,7 +789,7 @@ void spvm_execute_GLSL450_PackSnorm4x8(spvm_word type, spvm_word id, spvm_word w
 
 	unsigned int res = 0;
 	for (spvm_word i = 0; i < 4; i++) {
-		char s = roundf(CLAMP(state->results[x].members[i].value.f, -1.0f, +1.0f) * 127.0f);
+		char s = roundf(SPVM_CLAMP(state->results[x].members[i].value.f, -1.0f, +1.0f) * 127.0f);
 		res |= s << (8 * i);
 	}
 	state->results[id].members[0].value.u = res;
@@ -800,7 +800,7 @@ void spvm_execute_GLSL450_PackUnorm4x8(spvm_word type, spvm_word id, spvm_word w
 
 	unsigned int res = 0;
 	for (spvm_word i = 0; i < 4; i++) {
-		unsigned char s = roundf(CLAMP(state->results[x].members[i].value.f, 0.0f, +1.0f) * 255.0f);
+		unsigned char s = roundf(SPVM_CLAMP(state->results[x].members[i].value.f, 0.0f, +1.0f) * 255.0f);
 		res |= s << (8 * i);
 	}
 	state->results[id].members[0].value.u = res;
@@ -811,7 +811,7 @@ void spvm_execute_GLSL450_PackSnorm2x16(spvm_word type, spvm_word id, spvm_word 
 
 	unsigned int res = 0;
 	for (spvm_word i = 0; i < 2; i++) {
-		short s = roundf(CLAMP(state->results[x].members[i].value.f, -1.0f, +1.0f) * 32767.0f);
+		short s = roundf(SPVM_CLAMP(state->results[x].members[i].value.f, -1.0f, +1.0f) * 32767.0f);
 		res |= s << (16 * i);
 	}
 	state->results[id].members[0].value.u = res;
@@ -822,7 +822,7 @@ void spvm_execute_GLSL450_PackUnorm2x16(spvm_word type, spvm_word id, spvm_word 
 
 	unsigned int res = 0;
 	for (spvm_word i = 0; i < 2; i++) {
-		unsigned short s = roundf(CLAMP(state->results[x].members[i].value.f, 0.0f, +1.0f) * 65535.0f);
+		unsigned short s = roundf(SPVM_CLAMP(state->results[x].members[i].value.f, 0.0f, +1.0f) * 65535.0f);
 		res |= s << (16 * i);
 	}
 	state->results[id].members[0].value.u = res;
@@ -972,7 +972,7 @@ void spvm_execute_GLSL450_UnpackUnorm2x16(spvm_word type, spvm_word id, spvm_wor
 	unsigned int res = state->results[x].members[0].value.u;
 	for (spvm_word i = 0; i < 2; i++) {
 		unsigned short s = res >> (16 * i);
-		state->results[id].members[i].value.f = CLAMP(s / 65535.0f, 0.0f, +1.0f);
+		state->results[id].members[i].value.f = SPVM_CLAMP(s / 65535.0f, 0.0f, +1.0f);
 	}
 }
 void spvm_execute_GLSL450_UnpackSnorm2x16(spvm_word type, spvm_word id, spvm_word word_count, spvm_state_t state)
@@ -982,7 +982,7 @@ void spvm_execute_GLSL450_UnpackSnorm2x16(spvm_word type, spvm_word id, spvm_wor
 	unsigned int res = state->results[x].members[0].value.u;
 	for (spvm_word i = 0; i < 2; i++) {
 		short s = res >> (16 * i);
-		state->results[id].members[i].value.f = CLAMP(s / 32767.0f, -1.0f, +1.0f);
+		state->results[id].members[i].value.f = SPVM_CLAMP(s / 32767.0f, -1.0f, +1.0f);
 	}
 }
 void spvm_execute_GLSL450_UnpackUnorm4x8(spvm_word type, spvm_word id, spvm_word word_count, spvm_state_t state)
@@ -992,7 +992,7 @@ void spvm_execute_GLSL450_UnpackUnorm4x8(spvm_word type, spvm_word id, spvm_word
 	unsigned int res = state->results[x].members[0].value.u;
 	for (spvm_word i = 0; i < 4; i++) {
 		unsigned char s = res >> (8 * i);
-		state->results[id].members[i].value.f = CLAMP(s / 255.0f, 0.0f, +1.0f);
+		state->results[id].members[i].value.f = SPVM_CLAMP(s / 255.0f, 0.0f, +1.0f);
 	}
 }
 void spvm_execute_GLSL450_UnpackSnorm4x8(spvm_word type, spvm_word id, spvm_word word_count, spvm_state_t state)
@@ -1002,7 +1002,7 @@ void spvm_execute_GLSL450_UnpackSnorm4x8(spvm_word type, spvm_word id, spvm_word
 	unsigned int res = state->results[x].members[0].value.u;
 	for (spvm_word i = 0; i < 4; i++) {
 		char s = res >> (8 * i);
-		state->results[id].members[i].value.f = CLAMP(s / 127.0f, -1.0f, +1.0f);
+		state->results[id].members[i].value.f = SPVM_CLAMP(s / 127.0f, -1.0f, +1.0f);
 	}
 }
 void spvm_execute_GLSL450_Length(spvm_word type, spvm_word id, spvm_word word_count, spvm_state_t state)
@@ -1213,10 +1213,10 @@ void spvm_execute_GLSL450_NMin(spvm_word type, spvm_word id, spvm_word word_coun
 
 	if (type_info->value_bitcount > 32)
 		for (spvm_word i = 0; i < state->results[id].member_count; i++)
-			state->results[id].members[i].value.d = NMIN(state->results[x].members[i].value.d, state->results[y].members[i].value.d);
+			state->results[id].members[i].value.d = SPVM_NMIN(state->results[x].members[i].value.d, state->results[y].members[i].value.d);
 	else
 		for (spvm_word i = 0; i < state->results[id].member_count; i++)
-			state->results[id].members[i].value.f = NMIN(state->results[x].members[i].value.f, state->results[y].members[i].value.f);
+			state->results[id].members[i].value.f = SPVM_NMIN(state->results[x].members[i].value.f, state->results[y].members[i].value.f);
 }
 void spvm_execute_GLSL450_NMax(spvm_word type, spvm_word id, spvm_word word_count, spvm_state_t state)
 {
@@ -1227,10 +1227,10 @@ void spvm_execute_GLSL450_NMax(spvm_word type, spvm_word id, spvm_word word_coun
 
 	if (type_info->value_bitcount > 32)
 		for (spvm_word i = 0; i < state->results[id].member_count; i++)
-			state->results[id].members[i].value.d = NMAX(state->results[x].members[i].value.d, state->results[y].members[i].value.d);
+			state->results[id].members[i].value.d = SPVM_NMAX(state->results[x].members[i].value.d, state->results[y].members[i].value.d);
 	else
 		for (spvm_word i = 0; i < state->results[id].member_count; i++)
-			state->results[id].members[i].value.f = NMAX(state->results[x].members[i].value.f, state->results[y].members[i].value.f);
+			state->results[id].members[i].value.f = SPVM_NMAX(state->results[x].members[i].value.f, state->results[y].members[i].value.f);
 }
 void spvm_execute_GLSL450_NClamp(spvm_word type, spvm_word id, spvm_word word_count, spvm_state_t state)
 {
@@ -1242,14 +1242,14 @@ void spvm_execute_GLSL450_NClamp(spvm_word type, spvm_word id, spvm_word word_co
 
 	if (type_info->value_bitcount > 32)
 		for (spvm_word i = 0; i < state->results[id].member_count; i++) {
-			state->results[id].members[i].value.d = NCLAMP(state->results[x].members[i].value.d, state->results[minVal].members[i].value.d, state->results[maxVal].members[i].value.d);
+			state->results[id].members[i].value.d = SPVM_NCLAMP(state->results[x].members[i].value.d, state->results[minVal].members[i].value.d, state->results[maxVal].members[i].value.d);
 
 			if (state->analyzer && state->results[minVal].members[i].value.d > state->results[maxVal].members[i].value.d)
 				state->analyzer->on_undefined_behavior(state, spvm_undefined_behavior_clamp);
 		}
 	else
 		for (spvm_word i = 0; i < state->results[id].member_count; i++) {
-			state->results[id].members[i].value.f = NCLAMP(state->results[x].members[i].value.f, state->results[minVal].members[i].value.f, state->results[maxVal].members[i].value.f);
+			state->results[id].members[i].value.f = SPVM_NCLAMP(state->results[x].members[i].value.f, state->results[minVal].members[i].value.f, state->results[maxVal].members[i].value.f);
 
 			if (state->analyzer && state->results[minVal].members[i].value.f > state->results[maxVal].members[i].value.f)
 				state->analyzer->on_undefined_behavior(state, spvm_undefined_behavior_clamp);
@@ -1259,7 +1259,7 @@ void spvm_execute_GLSL450_NClamp(spvm_word type, spvm_word id, spvm_word word_co
 spvm_ext_opcode_func* spvm_build_glsl450_ext()
 {
 	spvm_ext_opcode_func* ret = (spvm_ext_opcode_func*)calloc(GLSLstd450Count, sizeof(spvm_ext_opcode_func));
-	
+
 	ret[GLSLstd450Round] = spvm_execute_GLSL450_Round;
 	ret[GLSLstd450RoundEven] = spvm_execute_GLSL450_RoundEven;
 	ret[GLSLstd450Trunc] = spvm_execute_GLSL450_Trunc;
@@ -1340,6 +1340,6 @@ spvm_ext_opcode_func* spvm_build_glsl450_ext()
 	ret[GLSLstd450NMin] = spvm_execute_GLSL450_NMin;
 	ret[GLSLstd450NMax] = spvm_execute_GLSL450_NMax;
 	ret[GLSLstd450NClamp] = spvm_execute_GLSL450_NClamp;
-	
+
 	return ret;
 }

--- a/src/image.c
+++ b/src/image.c
@@ -1,32 +1,303 @@
 #include <spvm/image.h>
 #include <spvm/value.h>
+#include <spvm/state.h>
+#include <spvm/result.h>
 #include <string.h>
+#include <assert.h>
 #include <stdlib.h>
 #include <math.h>
 
-void spvm_image_create(spvm_image_t img, float* data, int width, int height, int depth)
-{
-	img->data = (float*)calloc(width * height * depth * 4, sizeof(float));
-	memcpy(img->data, data, sizeof(float) * width * height * depth * 4);
+void spvm_image_create_ext(struct spvm_image_data* dst, float* data,
+		int width, int height, int depth, int layers, int levels) {
+	dst->base.width = width;
+	dst->base.height = height;
+	dst->base.depth = depth;
+	dst->base.layers = layers;
+	dst->base.levels = levels;
+	dst->data = (spvm_vec4f*) data;
+}
 
-	img->width = width;
-	img->height = height;
-	img->depth = depth;
+void spvm_image_create(struct spvm_image_data* dst, float* data,
+		int width, int height, int depth) {
+	spvm_image_create_ext(dst, data, width, height, depth, 1, 1);
 }
-float* spvm_image_sample(spvm_image_t img, float s, float t, float u)
-{
-	int x = roundf((img->width - 1) * CLAMP(s, 0.0f, 1.0f)); // nearest neighbor (?)
-	int y = roundf((img->height - 1) * CLAMP(t, 0.0f, 1.0f));
-	int z = (img->depth - 1) * CLAMP(fmodf(u, 1.0f), 0.0f, 1.0f);
 
-	return img->data + (z * img->height * img->width + y * img->width + x) * 4;
-}
-float* spvm_image_read(spvm_image_t img, int x, int y, int z)
+spvm_vec4f spvm_image_read(struct spvm_state* state, spvm_image* image,
+	int x, int y, int z, int layer, int level)
 {
-	return img->data + (z * img->height * img->width + y * img->width + x) * 4;
+	assert(state->read_image);
+	return state->read_image(state, image, x, y, z, layer, level);
 }
-void spvm_image_write(spvm_image_t img, int x, int y, int z, float* rgba)
+
+void spvm_image_write(struct spvm_state* state, spvm_image* image,
+	int x, int y, int z, int layer, int level, const spvm_vec4f* data)
 {
-	if (x < img->width && y < img->height && z < img->depth)
-		memcpy(img->data + (z * img->height * img->width + y * img->width + x) * 4, rgba, sizeof(float) * 4);
+	assert(state->write_image);
+	state->write_image(state, image, x, y, z, layer, level, data);
 }
+
+unsigned spvm_image_texel_id(struct spvm_image* image,
+	int x, int y, int z, int layer, int level)
+{
+	unsigned width = image->width;
+	unsigned height = image->height;
+	unsigned depth = image->depth;
+	unsigned off = 0u;
+
+	for(int l = 0; l < level; ++l)
+	{
+		width = SPVM_MAX(width >> 1u, 1u);
+		height = SPVM_MAX(height >> 1u, 1u);
+		depth = SPVM_MAX(depth >> 1u, 1u);
+		off += width * height * depth * image->layers;
+	}
+
+	unsigned sliceSize = width * height;
+	unsigned layerSize = depth * sliceSize;
+
+	off += layer * layerSize;
+	off += z * sliceSize;
+	off += y * width;
+	off += x;
+
+	return off;
+}
+
+spvm_vec4f spvm_image_read_impl(struct spvm_state* state, struct spvm_image* image,
+	int x, int y, int z, int layer, int level)
+{
+	spvm_image_data* data = (spvm_image_data*) image;
+	unsigned off = spvm_image_texel_id(image, x, y, z, layer, level);
+	return data->data[off];
+}
+
+void spvm_image_write_impl(struct spvm_state* state, struct spvm_image* image,
+	int x, int y, int z, int layer, int level, const spvm_vec4f* newval)
+{
+	spvm_image_data* data = (spvm_image_data*) image;
+	unsigned off = spvm_image_texel_id(image, x, y, z, layer, level);
+	data->data[off] = *newval;
+}
+
+// For the sampling implementation, see
+// https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/chap16.html#textures-texel-filtering
+// There are a lot of corner cases we are not handling currently.
+
+int spvm_util_mirror(int n)
+{
+	return (n >= 0) ? n : -(1 + n);
+}
+
+// Returns -1 for border.
+int spvm_apply_address_mode(spvm_sampler_address_mode mode, int val, int size)
+{
+	switch(mode)
+	{
+		case spvm_sampler_address_mode_repeat:
+			return ((val % size) + size) % size;
+		case spvm_sampler_address_mode_clamp_to_edge:
+			return SPVM_CLAMP(val, 0.f, size - 1);
+		case spvm_sampler_address_mode_clamp_to_border:
+			return (val < 0 || val >= size) ? -1 : val;
+		case spvm_sampler_address_mode_mirrored_repeat: {
+			int t = ((val % (2 * size)) + 2 * size) % (2 * size) - size;
+			return (size - 1) * spvm_util_mirror(t);
+		}
+	}
+
+	assert(0);
+	return -1;
+}
+
+float spvm_frac(float val)
+{
+	double iptr;
+	return modf(val, &iptr);
+}
+
+spvm_vec4f spvm_fetch_texel(struct spvm_state* state,
+	spvm_image* img, const spvm_sampler_desc* desc, int x, int y, int z, int layer, int level)
+{
+	layer = SPVM_CLAMP(layer, 0, img->layers - 1);
+	level = SPVM_CLAMP(level, 0, img->levels - 1);
+
+	unsigned width = SPVM_MAX(img->width >> level, 1u);
+	unsigned height = SPVM_MAX(img->height >> level, 1u);
+	unsigned depth = SPVM_MAX(img->depth >> level, 1u);
+
+	x = spvm_apply_address_mode(desc->address_mode_u, x, width);
+	y = spvm_apply_address_mode(desc->address_mode_v, y, height);
+	z = spvm_apply_address_mode(desc->address_mode_w, z, depth);
+
+	// check for border condition
+	if (x < 0 || y < 0 || z < 0) {
+		return desc->border_color;
+	}
+
+	return spvm_image_read_impl(state, img, x, y, z, layer, level);
+}
+
+spvm_vec4f spvm_sampled_image_sample(struct spvm_state* state,
+	spvm_image* img, spvm_sampler* sampler,
+	float s, float t, float r, float layer, float level)
+{
+	spvm_sampler_desc* desc = &sampler->desc;
+
+	level = SPVM_CLAMP(level + desc->mip_bias, desc->min_lod, desc->max_lod);
+	spvm_sampler_filter filter = (level <= 0.f) ? desc->filter_mag : desc->filter_min;
+
+	int levels[2];
+	float level_weights[2];
+	unsigned num_level_samples;
+
+	if(desc->mipmap_mode == spvm_sampler_filter_nearest)
+	{
+		num_level_samples = 1u;
+		levels[0] = roundf(level);
+		levels[1] = levels[0];
+		level_weights[0] = 1.f;
+		level_weights[1] = 0.f;
+	}
+	else
+	{
+		num_level_samples = 2u;
+		levels[0] = floor(level);
+		levels[1] = levels[0] + 1;
+		level_weights[0] = 1 - (level - levels[0]);
+		level_weights[1] = level - levels[0];
+	}
+
+	spvm_vec4f res = {0.f};
+
+	for(unsigned l = 0u; l < num_level_samples; ++l)
+	{
+		unsigned level = SPVM_CLAMP(levels[l], 0, img->levels - 1);
+		unsigned width = SPVM_MAX(img->width >> level, 1u);
+		unsigned height = SPVM_MAX(img->height >> level, 1u);
+		unsigned depth = SPVM_MAX(img->depth >> level, 1u);
+
+		float u = width * s;
+		float v = height * t;
+		float w = depth * r;
+
+		const float shift = 0.5f;
+
+		if (filter == spvm_sampler_filter_nearest)
+		{
+			int i = roundf(u - shift);
+			int j = roundf(v - shift);
+			int k  = roundf(w - shift);
+			spvm_vec4f sample = spvm_fetch_texel(state, img, desc,
+				i, j, k, roundf(layer), level);
+
+			for(unsigned j = 0u; j < 4; ++j)
+				res.data[j] += level_weights[l] * sample.data[j];
+		}
+		else
+		{
+			int i0 = floor(u - shift);
+			int j0 = floor(v - shift);
+			int k0 = floor(w - shift);
+
+			int i1 = i0 + 1;
+			int j1 = j0 + 1;
+			int k1 = k0 + 1;
+
+			float alpha = spvm_frac(u - shift);
+			float beta = spvm_frac(v - shift);
+			float gamma = spvm_frac(w - shift);
+
+			for(unsigned s = 0u; s < 8; ++s)
+			{
+				int i = (s & 1) ? i0 : i1;
+				int j = (s & 2) ? j0 : j1;
+				int k = (s & 4) ? k0 : k1;
+
+				float lin_weight =
+					((s & 1) ? (1 - alpha) : alpha) *
+					((s & 2) ? (1 - beta) : beta) *
+					((s & 4) ? (1 - gamma) : gamma);
+
+				spvm_vec4f sample = spvm_fetch_texel(state, img, desc,
+					i, j, k, roundf(layer), level);
+
+				for(unsigned j = 0u; j < 4; ++j)
+					res.data[j] += lin_weight * level_weights[l] * sample.data[j];
+			}
+
+		}
+	}
+
+	return res;
+}
+
+struct spvm_sampled_image_lod_query spvm_sampled_image_query_lod(
+		struct spvm_state* state, spvm_image* image, const struct spvm_image_info* imginfo,
+		spvm_sampler* sampler, unsigned coord_id, float shader_lod_bias, float shader_lod_min)
+{
+	// https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/chap16.html#textures-lod-and-scale-factor
+	// TODO: handle proj
+	// TODO: handle unnormalized sampling coords
+	// TODO: handle cubemaps
+
+	spvm_state_ddx(state, coord_id);
+	spvm_state_ddy(state, coord_id);
+
+	return spvm_sampled_image_query_lod_from_grad(state, image, imginfo,
+		sampler, state->derivative_buffer_x, state->derivative_buffer_y,
+		shader_lod_bias, shader_lod_min);
+}
+
+struct spvm_sampled_image_lod_query spvm_sampled_image_query_lod_from_grad(
+	struct spvm_state* state, spvm_image* image, const struct spvm_image_info* imginfo,
+	spvm_sampler* sampler, float* ddx, float* ddy,
+	float shader_lod_bias, float shader_lod_min)
+{
+
+	float mx[3] = {0.f};
+	float my[3] = {0.f};
+
+	mx[0] = ddx[0] * image->width;
+	my[0] = ddy[0] * image->width;
+
+	if(imginfo->dim >= SpvDim2D) {
+		mx[1] = ddx[1] * image->height;
+		my[1] = ddy[1] * image->height;
+	}
+
+	if(imginfo->dim >= SpvDim3D) {
+		mx[2] = ddx[2] * image->depth;
+		my[2] = ddy[2] * image->depth;
+	}
+
+	float ro_x = sqrt(mx[0] * mx[0] + mx[1] * mx[1] + mx[2] * mx[2]);
+	float ro_y = sqrt(my[0] * my[0] + my[1] * my[1] + my[2] * my[2]);
+
+	float ro_max = SPVM_MAX(ro_x, ro_y);
+	float ro_min = SPVM_MIN(ro_x, ro_y);
+
+	// TODO: handle anisotropy
+	const float eta = 1.f;
+
+	float lambda_base = log2(ro_max / eta);
+
+	// NOTE: we don't clamp to any maxSamplerLodBias here
+	float lambda_prime = lambda_base + shader_lod_bias + sampler->desc.mip_bias;
+
+	float lod_min = SPVM_MAX(shader_lod_min, sampler->desc.min_lod);
+	float lod_max = sampler->desc.max_lod;
+
+	float lambda = SPVM_CLAMP(lambda_prime, lod_min, lod_max);
+	float dl = lambda;
+
+	if (sampler->desc.mipmap_mode == spvm_sampler_filter_nearest) {
+		dl = round(dl);
+	}
+
+	struct spvm_sampled_image_lod_query ret;
+	ret.dl = dl;
+	ret.lambda_prime = lambda_prime;
+
+	return ret;
+}
+

--- a/src/opcode_setup.c
+++ b/src/opcode_setup.c
@@ -41,7 +41,7 @@ void spvm_setup_OpMemberName(spvm_word word_count, spvm_state_t state)
 	spvm_word id = SPVM_READ_WORD(state->code_current);
 	spvm_word memb = SPVM_READ_WORD(state->code_current);
 
-	state->results[id].member_name_count = MAX(memb + 1, state->results[id].member_name_count);
+	state->results[id].member_name_count = SPVM_MAX(memb + 1, state->results[id].member_name_count);
 	state->results[id].member_name = (spvm_string*)realloc(state->results[id].member_name, sizeof(spvm_string) * state->results[id].member_name_count);
 
 	spvm_word slen = word_count - 2;
@@ -219,13 +219,21 @@ void spvm_setup_OpTypeImage(spvm_word word_count, spvm_state_t state)
 	if (word_count > 8)
 		info->access = SPVM_READ_WORD(state->code_current);
 }
+void spvm_setup_OpTypeSampler(spvm_word word_count, spvm_state_t state)
+{
+	spvm_word id = SPVM_READ_WORD(state->code_current);
+	state->results[id].type = spvm_result_type_type;
+	state->results[id].value_type = spvm_value_type_sampler;
+	state->results[id].pointer = SPVM_READ_WORD(state->code_current);
+	state->results[id].member_count = 1;
+}
 void spvm_setup_OpTypeSampledImage(spvm_word word_count, spvm_state_t state)
 {
 	spvm_word id = SPVM_READ_WORD(state->code_current);
 	state->results[id].type = spvm_result_type_type;
 	state->results[id].value_type = spvm_value_type_sampled_image;
 	state->results[id].pointer = SPVM_READ_WORD(state->code_current);
-	state->results[id].member_count = 1;
+	state->results[id].member_count = 2;
 }
 void spvm_setup_OpTypeArray(spvm_word word_count, spvm_state_t state)
 {
@@ -488,6 +496,7 @@ void _spvm_context_create_setup_table(spvm_context_t ctx)
 	ctx->opcode_setup[SpvOpTypeVector] = spvm_setup_OpTypeVector;
 	ctx->opcode_setup[SpvOpTypeMatrix] = spvm_setup_OpTypeMatrix;
 	ctx->opcode_setup[SpvOpTypeImage] = spvm_setup_OpTypeImage;
+	ctx->opcode_setup[SpvOpTypeSampler] = spvm_setup_OpTypeSampler;
 	ctx->opcode_setup[SpvOpTypeSampledImage] = spvm_setup_OpTypeSampledImage;
 	ctx->opcode_setup[SpvOpTypeArray] = spvm_setup_OpTypeArray;
 	ctx->opcode_setup[SpvOpTypeRuntimeArray] = spvm_setup_OpTypeRuntimeArray;

--- a/src/state.c
+++ b/src/state.c
@@ -25,6 +25,9 @@ spvm_state_t _spvm_state_create_base(spvm_program_t prog, spvm_byte force_derv, 
 	state->analyzer = NULL;
 	state->_derivative_is_group_member = is_derv_member;
 
+	state->read_image = spvm_image_read_impl;
+	state->write_image = spvm_image_write_impl;
+
 	for (size_t i = 0; i < prog->bound; i++)
 		state->results[i].storage_class = SpvStorageClassMax;
 
@@ -113,7 +116,7 @@ void spvm_state_prepare(spvm_state_t state, spvm_word fnLocation)
 	state->did_jump = 0;
 	state->discarded = 0;
 	state->instruction_count = 0;
-	
+
 	if (!state->_derivative_is_group_member) {
 		if (state->derivative_group_x) spvm_state_prepare(state->derivative_group_x, fnLocation);
 		if (state->derivative_group_y) spvm_state_prepare(state->derivative_group_y, fnLocation);
@@ -160,7 +163,7 @@ void spvm_state_copy_uniforms(spvm_state_t dst, spvm_state_t src)
 		if (dst->results[ptr].storage_class != SpvStorageClassUniform &&
 			dst->results[ptr].storage_class != SpvStorageClassUniformConstant)
 			continue;
-		
+
 		for (spvm_word j = 0; j < src->owner->bound; j++) {
 			const spvm_string name2 = src->results[j].name;
 			ptr = src->results[j].pointer;
@@ -229,7 +232,7 @@ void spvm_state_call_function(spvm_state_t state)
 	spvm_source cur_code = state->code_current;
 
 	while (state->code_current)
-	{ 
+	{
 		// read data
 		spvm_word opcode_data = SPVM_READ_WORD(state->code_current);
 		spvm_word word_count = ((opcode_data & (~SpvOpCodeMask)) >> SpvWordCountShift) - 1;

--- a/src/value.c
+++ b/src/value.c
@@ -1,4 +1,5 @@
 #include <spvm/value.h>
+#include <assert.h>
 
 void spvm_member_free(spvm_member_t source, spvm_word value_count)
 {
@@ -11,8 +12,8 @@ void spvm_member_free(spvm_member_t source, spvm_word value_count)
 void spvm_member_memcpy(spvm_member_t target, spvm_member_t source, spvm_word value_count)
 {
 	for (spvm_word i = 0; i < value_count; i++) {
-		target[i].image_data = source[i].image_data;
 		target[i].value.u64 = source[i].value.u64;
+		assert(target[i].member_count == source[i].member_count);
 		if (target[i].member_count != 0)
 			spvm_member_memcpy(target[i].members, source[i].members, target[i].member_count);
 	}


### PR DESCRIPTION
This implements a new API for image sampling with the following goals:

- **Handle sampler details in spvm, expose an interface for specifying them**. The sampler definition added here is kept very close to Vulkan, mapping OpenGL onto that shouldn't be too hard. The implementation of the sampling process is mostly a direct implementation of the Vulkan spec (should be more or less similar in OpenGL though) except that this PR doesn't handle some advanced cases (anisotropy, corner-sampled images, multisampling, unnormalized coords).
- **Allow applications to handle image reading/writing in a custom manner**. Not all applications might have the image as raw data, as it was previously required. It's handled here simply via callbacks in `spvm_state`.
  - I added an implementation of this API that is used by default and mirrors the old approach.
  - Note that `spvm_image` is now the "base" struct only containing basic image information and applications will extend that struct with their own information. The implementation mirroring the old approach is called `spvm_image_data` so we have an API incompatibility here. If that's a big issue we could change the names (using something like `spvm_image_base` for the interface instead) but I'd rather not.

More of a RFC on the API design for now, the implementation still has some TODOs, isn't well tested and I might have missed one or two changes from my modified spvm version that are already needed. I would be in favor of adding a small set of unit tests to spvm and be willing to write them.

This PR already contains some additional fixes that were needed/useful to implement the new sampling:

- We now always store the correct typeid in values (wasn't the case e.g. for vector values before)
- It seems that spvm previously allocated additional members for scalar values that are part of a struct. Those were not needed and never accessed and are removed now.
- added a `SPVM_` prefix to the macros. Surprisingly many projects think it's a good idea to define macros like `MIN` in their header files.
- seperate between image, sampler and sampled_image values. A `sampled_image` consists of two members: first the image, then the sampler.
- add an assert in `spvm_member_memcpy` that was useful during debugging and helps code documentation.
- my editor once again removed some whitespace before eol. Could split it off into a separate commit if it's an issue.